### PR TITLE
total_alleles_lower_bound too low

### DIFF
--- a/cluster_vcf_records/vcf_record_cluster.py
+++ b/cluster_vcf_records/vcf_record_cluster.py
@@ -104,7 +104,7 @@ class VcfRecordCluster:
         total_alleles_lower_bound = 1
         for x in snp_nucleotides:
             total_alleles_lower_bound *= len(x)
-        total_alleles_lower_bound += len(non_snps)
+        total_alleles_lower_bound *= len(non_snps)
 
         if max_alleles is not None and total_alleles_lower_bound > max_alleles:
             return None


### PR DESCRIPTION
Line 112: seems to me like the for loop adds len(non_snps) ALT sequences **per** snp combination; in which case, the `total_alleles_lower_bound` needs not a `+= `, but a `*=`?

Also: if there can be duplicate combinations, should `total_alleles_lower_bound` not be an upper bound for the number of ALTs? Ie, that number could in truth be lower if you remove duplicates.

Also: why create all combinations of SNPs but not `non_snp`s?