### PR TITLE
include license file when distributing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include requirements.txt
+include LICENSE


### PR DESCRIPTION
As stated in both the [MIT license](https://opensource.org/licenses/MIT) and [python docs](https://packaging.python.org/tutorials/packaging-projects/#creating-a-license) it is good practice to include the license file when distributing software.  