### PR TITLE
Variant tracking: use all alleles

### DIFF
--- a/cluster_vcf_records/utils.py
+++ b/cluster_vcf_records/utils.py
@@ -32,7 +32,12 @@ def syscall(command):
 
 
 def simplify_vcf(
-    infile, outfile, ref_seqs=None, keep_ref_calls=False, max_ref_call_alleles=10
+    infile,
+    outfile,
+    ref_seqs=None,
+    keep_ref_calls=False,
+    max_ref_call_alleles=10,
+    keep_all_alleles=False,
 ):
     """Removes records that are all null calls and (optionally) ref calls.
     If record has GT, removes all non-called alleles and replaces FORMAT
@@ -63,8 +68,11 @@ def simplify_vcf(
                     if "." in gt_indexes:
                         continue
                     gt_indexes = {int(x) for x in gt_indexes}
+                    original_gt = record.FORMAT["GT"]
                     record.FORMAT.clear()
-                    if gt_indexes == {0}:
+                    if keep_all_alleles:
+                        record.FORMAT = {"GT": original_gt}
+                    elif gt_indexes == {0}:
                         if keep_ref_calls and len(record.ALT) <= max_ref_call_alleles:
                             record.set_format_key_value("GT", "0/0")
                         else:
@@ -117,7 +125,7 @@ def cat_vcfs(vcf_files, outfile, delete_files=False):
     with open(outfile, "a") as f_out:
         for vcf in vcf_files[1:]:
             with open(vcf) as f_in:
-                for line in  f_in:
+                for line in f_in:
                     if not line.startswith("#"):
                         print(line, end="", file=f_out)
             if delete_files:
@@ -131,7 +139,7 @@ def cat_tsvs(tsv_files, outfile, delete_files=False):
     with open(outfile, "a") as f_out:
         for tsv in tsv_files[1:]:
             with open(tsv) as f_in:
-                for i, line in  enumerate(f_in):
+                for i, line in enumerate(f_in):
                     if i > 1:
                         print(line, end="", file=f_out)
             if delete_files:

--- a/cluster_vcf_records/variant_tracking.py
+++ b/cluster_vcf_records/variant_tracking.py
@@ -171,7 +171,7 @@ class VariantBlock:
         if len(self.bitarrays) == 0:
             return 0
         else:
-            return self.bitarrays[0].length()
+            return len(self.bitarrays[0])
 
     def number_of_variants(self):
         return len(self.bitarrays)
@@ -250,7 +250,7 @@ def var_patterns_from_block_slices(block_files, wanted_variants, seq_id, start, 
         if len(block) == 0:
             continue
         sorted_vars = sorted(list(block.keys()))
-        samples = block[sorted_vars[0]].length()
+        samples = len(block[sorted_vars[0]])
 
         for i in range(samples):
             var_pattern = tuple(sorted([v for v in sorted_vars if block[v][i]]))

--- a/tests/data/utils/simplify_vcf.expect_keep_all_alleles.vcf
+++ b/tests/data/utils/simplify_vcf.expect_keep_all_alleles.vcf
@@ -1,0 +1,10 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample
+ref.1	1	.	A	T,G	.	PASS	.	GT	1/1
+ref.1	5	.	C	G	.	PASS	.	.	.
+ref.1	10	.	A	T,G	.	PASS	.	GT	0/2
+ref.1	15	.	A	T,C	.	PASS	.	GT	2/2
+ref.1	20	.	A	T,C	.	PASS	.	GT	0/0
+ref.1	25	.	A	G,T,C	.	PASS	.	GT	1/3
+ref.1	30	.	A	T,C	.	PASS	.	GT	0/2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,10 @@ def test_simplify_vcf():
     expect = os.path.join(data_dir, "simplify_vcf.expect_keep_ref_calls.vcf")
     assert filecmp.cmp(tmp_out, expect, shallow=False)
     os.unlink(tmp_out)
+    utils.simplify_vcf(infile, tmp_out, ref_seqs=ref_seqs, keep_all_alleles=True)
+    expect = os.path.join(data_dir, "simplify_vcf.expect_keep_all_alleles.vcf")
+    assert filecmp.cmp(tmp_out, expect, shallow=False)
+    os.unlink(tmp_out)
 
 
 def test_normalise_vcf():

--- a/tests/test_variant_tracking.py
+++ b/tests/test_variant_tracking.py
@@ -5,7 +5,7 @@ import pytest
 from bitarray import bitarray
 import pyfastaq
 
-from cluster_vcf_records import utils, variant_tracking, vcf_record
+from cluster_vcf_records import utils, variant_tracking, vcf_file_read, vcf_record
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(this_dir, "data", "variant_tracking")
@@ -288,7 +288,11 @@ def test_VariantTracker_make_from_vcf_then_save_then_load_then_cluster():
     for block_file in expect_block_files:
         expect = os.path.join(expect_dir, block_file)
         got = os.path.join(root_dir, block_file)
-        assert filecmp.cmp(got, expect, shallow=False)
+        with vcf_file_read.open_vcf_file_for_reading(expect) as f:
+            expect_lines = [x.rstrip() for x in f]
+        with vcf_file_read.open_vcf_file_for_reading(got) as f:
+            got_lines = [x.rstrip() for x in f]
+        assert expect_lines == got_lines
         assert os.path.exists(f"{got}.tbi")
 
     # Now the root_dir exists, constructor should load data from directory

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = clean,py36
+envlist = clean,py3
 
 [testenv]
 deps =


### PR DESCRIPTION
Adds an option to use all alleles when clustering and merging VCF files. Intended to be used with minos for small number of input VCFs. Current behaviour could result in lower sensitivity because only called alleles are kept. Using this new option will mean all alleles in input VCFs are considered. We still want to keep this optional though, because minos regenotype pipeline needs to just use called alleles for efficiency.