### PR TITLE
Vcflib tweaks

### DIFF
--- a/.ci/install_dependencies.sh
+++ b/.ci/install_dependencies.sh
@@ -18,6 +18,8 @@ apt-get install -y \
   python3-pip \
   python3-setuptools \
   tabix \
+  libvcflib-tools \
+  wget \
   zlib1g-dev
 
 
@@ -45,14 +47,6 @@ git checkout 2187ff6347086e38f71bd9f8ca622cd7dcfbb40c
 make
 cd ..
 cp -s vt-git/vt .
-
-
-#______________________vcflib _________________________________#
-cd $install_root
-git clone --recursive https://github.com/vcflib/vcflib.git
-cd vcflib
-make
-
 
 #______________________ python ________________________________#
 pip3 install tox "six>=1.14.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 python:
 - '3.6'

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Used by gramtools and minos - written specifically for those projects and no oth
 ## Dependencies
 
 * [vt](https://genome.sph.umich.edu/wiki/Vt)
-* [vcflib](https://github.com/vcflib/vcflib). Specifically, needs `vcfbreakmulti`,
-  `vcfallelicprimitives`, and `vcfuniq` to be installed and in your `$PATH`.
+* [vcflib](https://github.com/vcflib/vcflib). Specifically, needs either
+  `vcflib`, or all three of `vcfbreakmulti`,
+  `vcfallelicprimitives`, `vcfuniq` to be installed and in your `$PATH`.
 * [bcftools](https://samtools.github.io/bcftools/). This is optional. Only
   needed if you need to read bcf files.
 

--- a/cluster_vcf_records/variant_tracking.py
+++ b/cluster_vcf_records/variant_tracking.py
@@ -171,7 +171,7 @@ class VariantBlock:
         if len(self.bitarrays) == 0:
             return 0
         else:
-            return self.bitarrays[0].length()
+            return len(self.bitarrays[0])
 
     def number_of_variants(self):
         return len(self.bitarrays)
@@ -250,7 +250,7 @@ def var_patterns_from_block_slices(block_files, wanted_variants, seq_id, start, 
         if len(block) == 0:
             continue
         sorted_vars = sorted(list(block.keys()))
-        samples = block[sorted_vars[0]].length()
+        samples = len(block[sorted_vars[0]])
 
         for i in range(samples):
             var_pattern = tuple(sorted([v for v in sorted_vars if block[v][i]]))

--- a/tests/test_variant_tracking.py
+++ b/tests/test_variant_tracking.py
@@ -5,7 +5,7 @@ import pytest
 from bitarray import bitarray
 import pyfastaq
 
-from cluster_vcf_records import utils, variant_tracking, vcf_record
+from cluster_vcf_records import utils, variant_tracking, vcf_file_read, vcf_record
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(this_dir, "data", "variant_tracking")
@@ -288,7 +288,11 @@ def test_VariantTracker_make_from_vcf_then_save_then_load_then_cluster():
     for block_file in expect_block_files:
         expect = os.path.join(expect_dir, block_file)
         got = os.path.join(root_dir, block_file)
-        assert filecmp.cmp(got, expect, shallow=False)
+        with vcf_file_read.open_vcf_file_for_reading(expect) as f:
+            expect_lines = [x.rstrip() for x in f]
+        with vcf_file_read.open_vcf_file_for_reading(got) as f:
+            got_lines = [x.rstrip() for x in f]
+        assert expect_lines == got_lines
         assert os.path.exists(f"{got}.tbi")
 
     # Now the root_dir exists, constructor should load data from directory


### PR DESCRIPTION
vcflib comes with lots of programs, 3 of which are used by this repo. Existing method has been to use vcflib compiled from source, but compiling has been causing issues. This PR changes to install using `apt` instead. However, installing in this way does not install all the individual scripts (which is what from source does), but instead a single program `vcflib`. The changes in this PR handle both installs, by looking first for the single `vcflib` program, then if not found looks for the individual programs.