### PR TITLE
Make alleles uppercase and ignore non-ACGT alleles

### DIFF
--- a/cluster_vcf_records/utils.py
+++ b/cluster_vcf_records/utils.py
@@ -53,6 +53,7 @@ def simplify_vcf(
                     )
                     continue
 
+                record.REF = record.REF.upper()
                 if ref_seqs is not None and not (
                     record.ref_string_matches_dict_of_ref_sequences(ref_seqs)
                 ):

--- a/cluster_vcf_records/variant_tracking.py
+++ b/cluster_vcf_records/variant_tracking.py
@@ -15,6 +15,8 @@ import pysam
 from cluster_vcf_records import allele_combinations, utils, vcf_file_read, vcf_record
 
 
+acgt_regex = re.compile("^[ACGTacgt]+$")
+
 Variant = namedtuple("Variant", ["seq_id", "pos", "ref", "alt"])
 
 
@@ -106,13 +108,13 @@ def _load_one_vcf_file(
                 continue
 
             for i in gt_indexes:
-                if i > 0:
+                if i > 0 and acgt_regex.match(record.ALT[i - 1]) is not None:
                     variants.append(
                         Variant(
                             ref_seq_to_id[record.CHROM],
                             record.POS,
                             record.REF,
-                            record.ALT[i - 1],
+                            record.ALT[i - 1].upper(),
                         )
                     )
 

--- a/tests/data/variant_tracking/load_one_vcf_file.vcf
+++ b/tests/data/variant_tracking/load_one_vcf_file.vcf
@@ -7,4 +7,7 @@ ref.1	4	.	G	GCCG	.	PASS	.	GT	1/1
 ref.2	1	.	T	C	.	PASS	.	GT	0/0
 ref.2	1	.	T	G	.	FAIL	.	GT	0/0
 ref.2	2	.	G	T,C	.	PASS	.	GT	2
-ref.2	2	.	G	A	.	PASS	.	GT	1/1
+ref.2	2	.	g	a	.	PASS	.	GT	1/1
+ref.2	2	.	g	a,<FOO>	.	PASS	.	GT	2
+ref.2	3	.	C	a,<FOO>	.	PASS	.	GT	1
+ref.2	4	.	A	<FOO>	.	PASS	.	GT	1

--- a/tests/test_variant_tracking.py
+++ b/tests/test_variant_tracking.py
@@ -256,6 +256,7 @@ def test_load_one_vcf_file():
         variant_tracking.Variant(seq_id=0, pos=8, ref="T", alt="G"),
         variant_tracking.Variant(seq_id=1, pos=1, ref="G", alt="C"),
         variant_tracking.Variant(seq_id=1, pos=1, ref="G", alt="A"),
+        variant_tracking.Variant(seq_id=1, pos=2, ref="C", alt="A"),
     ]
     assert got_variants == expect_variants
     os.rmdir(tmp_dir)


### PR DESCRIPTION
When loading VCF files for clustering, ignore alleles that are not comprised of only A,C,G,T. This is for minos issue: https://github.com/iqbal-lab-org/minos/issues/117
Also convert all ref/alts to uppercase for consistency/paranoia